### PR TITLE
Add driver for Photonic F3000 LED light source.

### DIFF
--- a/src/comet/driver/generic/__init__.py
+++ b/src/comet/driver/generic/__init__.py
@@ -13,3 +13,4 @@ from .motion_controller import (
     MotionController,
     MotionControllerAxis,
 )
+from .light_source import LightSource

--- a/src/comet/driver/generic/light_source.py
+++ b/src/comet/driver/generic/light_source.py
@@ -1,0 +1,26 @@
+from abc import abstractmethod
+
+__all__ = ["LightSource"]
+
+
+class LightSource(Driver):
+
+    @property
+    @abstractmethod
+    def brightness(self) -> int:
+        ...
+
+    @brightness.setter
+    @abstractmethod
+    def brightness(self, brightness: int) -> None:
+        ...
+
+    @property
+    @abstractmethod
+    def light_enabled(self) -> bool:
+        ...
+
+    @light_enabled.setter
+    @abstractmethod
+    def light_enabled(self, light_enabled: bool) -> None:
+        ...

--- a/src/comet/driver/generic/light_source.py
+++ b/src/comet/driver/generic/light_source.py
@@ -1,5 +1,7 @@
 from abc import abstractmethod
 
+from ..driver import Driver
+
 __all__ = ["LightSource"]
 
 
@@ -7,20 +9,16 @@ class LightSource(Driver):
 
     @property
     @abstractmethod
-    def brightness(self) -> int:
-        ...
+    def brightness(self) -> int: ...
 
     @brightness.setter
     @abstractmethod
-    def brightness(self, brightness: int) -> None:
-        ...
+    def brightness(self, brightness: int) -> None: ...
 
     @property
     @abstractmethod
-    def light_enabled(self) -> bool:
-        ...
+    def light_enabled(self) -> bool: ...
 
     @light_enabled.setter
     @abstractmethod
-    def light_enabled(self, light_enabled: bool) -> None:
-        ...
+    def light_enabled(self, light_enabled: bool) -> None: ...

--- a/src/comet/driver/generic/light_source.py
+++ b/src/comet/driver/generic/light_source.py
@@ -22,3 +22,6 @@ class LightSource(Driver):
     @light_enabled.setter
     @abstractmethod
     def light_enabled(self, light_enabled: bool) -> None: ...
+
+    @abstractmethod
+    def identify(self) -> str: ...

--- a/src/comet/driver/light/__init__.py
+++ b/src/comet/driver/light/__init__.py
@@ -1,0 +1,1 @@
+from .photonic import Photonic

--- a/src/comet/driver/light/__init__.py
+++ b/src/comet/driver/light/__init__.py
@@ -1,1 +1,0 @@
-from .photonic import Photonic

--- a/src/comet/driver/light/photonic.py
+++ b/src/comet/driver/light/photonic.py
@@ -1,0 +1,80 @@
+from comet.driver import Driver
+
+__all__ = ["Photonic"]
+
+
+class PhotonicDriver(Driver):
+    """Photonic LED light source base class"""
+
+    def __init__(self, resource):
+        self.resource = resource
+        self.resource.write_termination = "\r"
+        self.resource.read_termination = "\r"
+
+
+class Photonic(PhotonicDriver):
+    """Class for controlling Photonics F3000 LED light sources"""
+
+    @property
+    def brightness(self) -> int:
+        """Returns current brightness of light source
+            (0-100 percent)
+
+        Returns:
+            int . Brightness of light source in percent
+        """
+
+        self.resource.write("B?")
+        response = self.resource.read()
+
+        return int(response.replace("B", ""))
+
+    @brightness.setter
+    def brightness(self, brightness: int):
+        """Set brightness of light source in percent
+
+        Args:
+            brightness (int): Brightness to set in percent
+
+        Raises:
+            ValueError: Brightness outside of range [0,100]
+        """
+        brightness = int(brightness)
+        if brightness < 0 or brightness > 100:
+            raise ValueError("Brightness must be between 0 and 100")
+
+        self.resource.write(f"B{brightness}")
+        self.resource.read()
+
+    @property
+    def light_enabled(self) -> bool:
+        """Get current state of shutter (light source)
+
+        Returns:
+            str: State of light source (1 on, 0 off)
+        """
+        # self.ser.write(b"s\r")
+        # response = self.ser.readline().decode("ascii").strip()
+        # response = int(response.replace("S", ""))
+
+        self.resource.write("S?")
+        response = self.resource.read().replace("S", "")
+
+        if int(response) == 1:
+            return 0
+        elif int(response) == 0:
+            return 1
+
+    @light_enabled.setter
+    def light_enabled(self, light_enabled: bool):
+        """Turn on / off shutter (light source)
+
+        Args:
+            light_enabled (bool): Enable / Disable light source
+        """
+        if light_enabled:
+            self.resource.write("S0")
+        else:
+            self.resource.write("S1")
+
+        self.resource.read()

--- a/src/comet/driver/light/photonic.py
+++ b/src/comet/driver/light/photonic.py
@@ -53,10 +53,7 @@ class Photonic(PhotonicDriver):
         Returns:
             str: State of light source (1 on, 0 off)
         """
-        # self.ser.write(b"s\r")
-        # response = self.ser.readline().decode("ascii").strip()
-        # response = int(response.replace("S", ""))
-
+        
         self.resource.write("S?")
         response = self.resource.read().replace("S", "")
 

--- a/src/comet/driver/photonic/__init__.py
+++ b/src/comet/driver/photonic/__init__.py
@@ -1,0 +1,1 @@
+from .f3000 import F3000

--- a/src/comet/driver/photonic/f3000.py
+++ b/src/comet/driver/photonic/f3000.py
@@ -1,9 +1,9 @@
 from comet.driver import Driver
 
-__all__ = ["Photonic"]
+__all__ = ["F3000"]
 
 
-class PhotonicDriver(Driver):
+class F3000Driver(Driver):
     """Photonic LED light source base class"""
 
     def __init__(self, resource):
@@ -12,7 +12,7 @@ class PhotonicDriver(Driver):
         self.resource.read_termination = "\r"
 
 
-class Photonic(PhotonicDriver):
+class F3000(F3000Driver):
     """Class for controlling Photonics F3000 LED light sources"""
 
     @property
@@ -53,7 +53,7 @@ class Photonic(PhotonicDriver):
         Returns:
             str: State of light source (1 on, 0 off)
         """
-        
+
         self.resource.write("S?")
         response = self.resource.read().replace("S", "")
 

--- a/src/comet/driver/photonic/f3000.py
+++ b/src/comet/driver/photonic/f3000.py
@@ -43,10 +43,7 @@ class F3000(LightSource):
         self.resource.write("S?")
         response = self.resource.read().replace("S", "")
 
-        if int(response) == 1:
-            return 0
-        elif int(response) == 0:
-            return 1
+        return int(response) == 0
 
     @light_enabled.setter
     def light_enabled(self, light_enabled: bool):

--- a/src/comet/driver/photonic/f3000.py
+++ b/src/comet/driver/photonic/f3000.py
@@ -1,19 +1,16 @@
-from comet.driver import Driver
+from comet.driver.generic.light_source import LightSource
 
 __all__ = ["F3000"]
 
 
-class F3000Driver(Driver):
-    """Photonic LED light source base class"""
+class F3000(LightSource):
+    """Class for controlling Photonics F3000 LED light sources"""
 
     def __init__(self, resource):
+        super().__init__(resource)
         self.resource = resource
         self.resource.write_termination = "\r"
         self.resource.read_termination = "\r"
-
-
-class F3000(F3000Driver):
-    """Class for controlling Photonics F3000 LED light sources"""
 
     @property
     def brightness(self) -> int:

--- a/src/comet/driver/photonic/f3000.py
+++ b/src/comet/driver/photonic/f3000.py
@@ -35,13 +35,8 @@ class F3000(F3000Driver):
 
         Args:
             brightness (int): Brightness to set in percent
-
-        Raises:
-            ValueError: Brightness outside of range [0,100]
         """
-        brightness = int(brightness)
-        if brightness < 0 or brightness > 100:
-            raise ValueError("Brightness must be between 0 and 100")
+        brightness = max(0, min(100, brightness))
 
         self.resource.write(f"B{brightness}")
         self.resource.read()

--- a/src/comet/driver/photonic/f3000.py
+++ b/src/comet/driver/photonic/f3000.py
@@ -67,3 +67,8 @@ class F3000(LightSource):
             self.resource.write("S1")
 
         self.resource.read()
+
+    def identify(self):
+        """Acquire identification string"""
+        self.resource.write("V?")
+        return self.resource.read()

--- a/src/comet/driver/photonic/f3000.py
+++ b/src/comet/driver/photonic/f3000.py
@@ -6,12 +6,6 @@ __all__ = ["F3000"]
 class F3000(LightSource):
     """Class for controlling Photonics F3000 LED light sources"""
 
-    def __init__(self, resource):
-        super().__init__(resource)
-        self.resource = resource
-        self.resource.write_termination = "\r"
-        self.resource.read_termination = "\r"
-
     @property
     def brightness(self) -> int:
         """Returns current brightness of light source

--- a/src/comet/emulator/photonic/f3000.py
+++ b/src/comet/emulator/photonic/f3000.py
@@ -20,7 +20,7 @@ class F3000Emulator(Emulator):
         return self.IDENTITY
 
     @message(r"^B(\d{1,3})$")
-    def set_brightness(self, brightness: str) -> None:
+    def set_brightness(self, brightness: int) -> None:
         brightness = max(0, min(int(brightness), 100))
         self.current_brightness = int(brightness)
 

--- a/src/comet/emulator/photonic/f3000.py
+++ b/src/comet/emulator/photonic/f3000.py
@@ -1,0 +1,41 @@
+"""Photonic F3000 LED light source emulator"""
+
+from comet.emulator import Emulator
+from comet.emulator import message, run
+
+__all__ = ["F3000Emulator"]
+
+
+class F3000Emulator(Emulator):
+    IDENTITY: str = "F3000 v2.09, Emulator"
+
+    def __init__(self) -> None:
+        super().__init__()
+
+        self.current_brightness: int = 50
+        self.light_enabled: bool = False
+
+    @message(r"^V\?$")
+    def get_version(self) -> str:
+        return self.IDENTITY
+
+    @message(r"^B(\d{1,3})$")
+    def set_brightness(self, brightness: str) -> None:
+        brightness = max(0, min(int(brightness), 100))
+        self.current_brightness = int(brightness)
+
+    @message(r"^B\?$")
+    def get_brightness(self) -> str:
+        return "B" + str(self.current_brightness)
+
+    @message(r"^S\?$")
+    def get_light_enabled(self) -> str:
+        return "S0" if self.light_enabled else "S1"
+
+    @message(r"^S(0|1)$")
+    def set_light_enabled(self, light_enabled: str) -> None:
+        self.light_enabled = not bool(int(light_enabled))
+
+
+if __name__ == "__main__":
+    run(F3000Emulator())

--- a/tests/test_driver_photonic_f3000.py
+++ b/tests/test_driver_photonic_f3000.py
@@ -1,0 +1,64 @@
+import pytest
+
+from comet.driver.photonic import F3000
+
+from .test_driver import resource
+
+
+@pytest.fixture
+def driver(resource):
+    return F3000(resource)
+
+
+def test_identify(driver, resource):
+    resource.buffer = ["F3000 v2.09, Emulator"]
+    assert driver.identify() == "F3000 v2.09, Emulator"
+    assert resource.buffer == ["V?"]
+
+
+def test_read_brightness(driver, resource):
+    resource.buffer = ["B50"]
+    assert driver.brightness == 50
+    assert resource.buffer == ["B?"]
+
+
+def test_set_brightness(driver, resource):
+    resource.buffer = [""]
+    driver.brightness = 0
+    assert resource.buffer == ["B0"]
+
+    resource.buffer = [""]
+    driver.brightness = 50
+    assert resource.buffer == ["B50"]
+
+    resource.buffer = [""]
+    driver.brightness = 100
+    assert resource.buffer == ["B100"]
+
+    resource.buffer = [""]
+    driver.brightness = -1
+    assert resource.buffer == ["B0"]
+
+    resource.buffer = [""]
+    driver.brightness = 101
+    assert resource.buffer == ["B100"]
+
+
+def test_read_light_enabled(driver, resource):
+    resource.buffer = ["S1"]
+    assert driver.light_enabled == 0
+    assert resource.buffer == ["S?"]
+
+    resource.buffer = ["S0"]
+    assert driver.light_enabled == 1
+    assert resource.buffer == ["S?"]
+
+
+def test_set_light_enabled(driver, resource):
+    resource.buffer = [""]
+    driver.light_enabled = True
+    assert resource.buffer == ["S0"]
+
+    resource.buffer = [""]
+    driver.light_enabled = False
+    assert resource.buffer == ["S1"]

--- a/tests/test_driver_photonic_f3000.py
+++ b/tests/test_driver_photonic_f3000.py
@@ -36,10 +36,6 @@ def test_set_brightness(driver, resource):
     assert resource.buffer == ["B100"]
 
     resource.buffer = [""]
-    driver.brightness = -1
-    assert resource.buffer == ["B0"]
-
-    resource.buffer = [""]
     driver.brightness = 101
     assert resource.buffer == ["B100"]
 

--- a/tests/test_emulator_photonic_f3000.py
+++ b/tests/test_emulator_photonic_f3000.py
@@ -1,0 +1,42 @@
+import pytest
+
+from comet.emulator.photonic.f3000 import F3000Emulator
+
+
+@pytest.fixture
+def emulator():
+    return F3000Emulator()
+
+
+def test_identify(emulator):
+    assert emulator("V?") == "F3000 v2.09, Emulator"
+
+
+def test_read_brightness(emulator):
+    assert emulator("B?") == "B50"
+
+
+def test_set_brightness(emulator):
+    assert emulator("B0") == None
+    assert emulator("B?") == "B0"
+
+    assert emulator("B50") == None
+    assert emulator("B?") == "B50"
+
+    assert emulator("B100") == None
+    assert emulator("B?") == "B100"
+
+    assert emulator("B101") == None
+    assert emulator("B?") == "B100"
+
+
+def test_read_light_enabled(emulator):
+    assert emulator("S?") == "S1"
+
+
+def test_set_light_enabled(emulator):
+    assert emulator("S1") == None
+    assert emulator("S?") == "S1"
+
+    assert emulator("S0") == None
+    assert emulator("S?") == "S0"


### PR DESCRIPTION
Implements the brightness and standby commands for a Photonics F3000 Light Source.

For all commands (not yet implemented), see F3000 [documentation](https://www.photonic.at/wp-content/uploads/2018/04/Serial-Protocol-for-LED-light-source.pdf).

Emulator to follow.
