### PR TITLE
Implement ERS AC3 Thermal Chuck to comet

### DIFF
--- a/src/comet/driver/ers/__init__.py
+++ b/src/comet/driver/ers/__init__.py
@@ -1,0 +1,3 @@
+from .ac3 import AC3
+
+__all__ = ["AC3"]

--- a/src/comet/driver/ers/ac3.py
+++ b/src/comet/driver/ers/ac3.py
@@ -164,7 +164,8 @@ class AC3(Instrument):
         """Set hold mode state."""
         self._query(f"SH{int(state)}")
 
-    def get_control_status(self) -> int:
+    @property
+    def control_status(self) -> int:
         """Get control status."""
         response = self._query("RI")
 

--- a/src/comet/driver/ers/ac3.py
+++ b/src/comet/driver/ers/ac3.py
@@ -1,0 +1,123 @@
+""" Driver for ECR AC3 thermal chuck"""
+
+from typing import Tuple
+
+
+class AC3:
+    """AC3 Fusion TS010S temperature controller interface."""
+
+    # Operating mode constants
+    MODE_NORMAL = 1
+    MODE_STANDBY = 2
+    MODE_DEFROST = 3
+    MODE_PURGE = 4
+
+    STATUS_TEMPERATURE_REACHED = 0
+    STATUS_HEATING = 1
+    STATUS_COOLING = 2
+    STATUS_ERROR = 8
+
+    def __init__(self, resource):
+        self._resource = resource
+
+    def _query(self, message: str) -> str:
+        """Send query and validate response.
+
+        Args:
+            message: Command string to send
+
+        Returns:
+            Response string from device
+
+        Raises:
+            RuntimeError: If device returns error
+        """
+        response = self._resource.query(message)
+        if response.strip() == "?":
+            raise RuntimeError(f"Command failed: {message}")
+        return response.strip()
+
+    @property
+    def temperature(self) -> float:
+        """Get current chuck temperature in °C."""
+        response = self._query("RC")
+        # Format: Csxxxx where s is sign and xxxx is temperature in 1/10°C
+        value = float(response[1:]) / 10
+        return value
+
+    @property
+    def target_temperature(self) -> float:
+        """Get temperature setpoint in °C."""
+        response = self._query("RT")
+        # Format: Tvxxxx where v is sign and xxxx is temperature in 1/10°C
+        value = float(response[1:]) / 10
+        return value
+
+    @target_temperature.setter
+    def target_temperature(self, value: float) -> None:
+        """Set temperature setpoint in °C."""
+        # Convert to 1/10°C with sign
+        temp = int(value * 10)
+        # write sign explicitly
+        sign = "+" if temp >= 0 else "-"
+        temp_str = f"{sign}{abs(temp):04d}"
+
+    @property
+    def operating_mode(self) -> int:
+        """Get current operating mode."""
+        response = self._query("RO")
+        # Format: Oy where y is mode number
+        return int(response)
+
+    @operating_mode.setter
+    def operating_mode(self, mode: int) -> None:
+        """Set operating mode."""
+        self._query(f"SO{mode}")
+
+    @property
+    def dewpoint(self) -> float:
+        """Get measured dewpoint in °C."""
+        response = self._query("RF")
+        # Format: Fsxxxx where s is sign and xxxx is dewpoint in 1/10°C
+        value = float(response[1:]) / 10
+        return value
+
+    @property
+    def dewpoint_control(self) -> bool:
+        """Get dewpoint control status."""
+        response = self._query("RD")
+        # Format: Dy where y is 0 (off) or 1 (on)
+        return bool(int(response))
+
+    @dewpoint_control.setter
+    def dewpoint_control(self, state: bool) -> None:
+        """Set dewpoint control state."""
+        self._query(f"SD{int(state)}")
+
+    @property
+    def hold_mode(self) -> bool:
+        """Get hold mode status."""
+        response = self._query("RH")
+
+        # y = 00: «Hold Mode» not active
+        # y = 10: «Hold Mode» set but not yet reached
+        # yy = 11: : «Hold Mode» set and reached
+
+        return bool(int(response[1]))
+
+    @hold_mode.setter
+    def hold_mode(self, state: bool) -> None:
+        """Set hold mode state."""
+        self._query(f"SH{int(state)}")
+
+    def get_control_status(self) -> int:
+        """Get control status."""
+        response = self._query("RI")
+
+        return int(response[1])
+
+    def get_error_status(self) -> int:
+        """Get error status code."""
+        response = self._query("RE")
+        # Format: Eyyy where yyy is error code
+        return int(response[1:])

--- a/src/comet/driver/ers/ac3.py
+++ b/src/comet/driver/ers/ac3.py
@@ -7,15 +7,15 @@ class AC3:
     """AC3 Fusion TS010S temperature controller interface."""
 
     # Operating mode constants
-    MODE_NORMAL = 1
-    MODE_STANDBY = 2
-    MODE_DEFROST = 3
-    MODE_PURGE = 4
+    MODE_NORMAL: int = 1
+    MODE_STANDBY: int = 2
+    MODE_DEFROST: int = 3
+    MODE_PURGE: int = 4
 
-    STATUS_TEMPERATURE_REACHED = 0
-    STATUS_HEATING = 1
-    STATUS_COOLING = 2
-    STATUS_ERROR = 8
+    STATUS_TEMPERATURE_REACHED: int = 0
+    STATUS_HEATING: int = 1
+    STATUS_COOLING: int = 2
+    STATUS_ERROR: int = 8
 
     def __init__(self, resource):
         self._resource = resource

--- a/src/comet/driver/ers/ac3.py
+++ b/src/comet/driver/ers/ac3.py
@@ -3,6 +3,8 @@
 from typing import Tuple
 
 
+__all__ = ["AC3"]
+
 class AC3:
     """AC3 Fusion TS010S temperature controller interface."""
 

--- a/src/comet/driver/ers/ac3.py
+++ b/src/comet/driver/ers/ac3.py
@@ -56,21 +56,29 @@ class AC3:
     @target_temperature.setter
     def target_temperature(self, value: float) -> None:
         """Set temperature setpoint in °C."""
+
+        if value > 300 or value < -70:
+            raise ValueError("Temperature {} is out of range -70 to 300C".format(value))
+
         # Convert to 1/10°C with sign
         temp = int(value * 10)
         # write sign explicitly
         sign = "+" if temp >= 0 else "-"
         temp_str = f"{sign}{abs(temp):04d}"
 
+        self._query(f"ST{temp_str}")
+
     @property
     def operating_mode(self) -> int:
         """Get current operating mode."""
         response = self._query("RO")
         # Format: Oy where y is mode number
-        return int(response)
+        return int(response[1])
 
     @operating_mode.setter
     def operating_mode(self, mode: int) -> None:
+        if mode not in range(1, 5):
+            raise ValueError("Invalid mode: {}".format(mode))
         """Set operating mode."""
         self._query(f"SO{mode}")
 
@@ -87,7 +95,7 @@ class AC3:
         """Get dewpoint control status."""
         response = self._query("RD")
         # Format: Dy where y is 0 (off) or 1 (on)
-        return bool(int(response))
+        return bool(int(response[1]))
 
     @dewpoint_control.setter
     def dewpoint_control(self, state: bool) -> None:

--- a/src/comet/emulator/ers/ac3.py
+++ b/src/comet/emulator/ers/ac3.py
@@ -1,0 +1,77 @@
+"""Driver for ECR AC3 thermal chuck"""
+
+from typing import Tuple
+
+from comet.emulator import Emulator
+from comet.emulator import message, run
+
+__all__ = ["AC3Emulator"]
+
+
+class AC3Emulator(Emulator):
+    def __init__(self) -> None:
+        super().__init__()
+
+        self.temperature: float = 25.0
+        self.target_temperature: float = 25.0
+        self.mode: int = 1
+        self.control_status: int = 1
+        self.hold_mode: int = 11
+        self.dewpoint_control_status: bool = True
+        self.dewpoint: float = -20.0
+
+    @message(r"^RC$")
+    def get_temperature(self) -> str:
+        return f"C{int(self.temperature*10):+05d}"
+
+    @message(r"^RT$")
+    def get_target_temperature(self) -> str:
+        return f"T{int(self.target_temperature*10):+05d}"
+
+    @message(r"^ST([+-]\d{4})$")
+    def set_target_temperature(self, value: str) -> str:
+        self.target_temperature = float(value) / 10
+        return "OK"
+
+    @message(r"^RO$")
+    def get_mode(self) -> str:
+        return f"O{self.mode}"
+
+    @message(r"^SO([1234])$")
+    def set_mode(self, value: str) -> str:
+        self.mode = int(value)
+        return "OK"
+
+    @message(r"^RF$")
+    def get_dewpoint(self) -> str:
+        return f"F{int(self.dewpoint*10):+05d}"
+
+    @message(r"^RD$")
+    def get_dewpoint_control_status(self) -> str:
+        return f"D{int(self.dewpoint_control_status)}"
+
+    @message(r"^SD([01])$")
+    def set_dewpoint_control_status(self, value: str) -> str:
+        self.dewpoint_control_status = bool(int(value))
+        return "OK"
+
+    @message(r"^RH$")
+    def get_hold_mode(self) -> str:
+        return f"H{self.hold_mode:02d}"
+
+    @message(r"^SH([01][01])$")
+    def set_hold_mode(self, value: str) -> str:
+        val = int(value)
+        if val == 0:
+            self.hold_mode = 0
+        else:
+            self.hold_mode = 11
+        return "OK"
+
+    @message(r"^RI$")
+    def get_control_status(self) -> str:
+        return f"I{self.control_status}"
+
+    @message(r"^RE$")
+    def get_error(self) -> str:
+        return "E00"

--- a/src/comet/emulator/ers/ac3.py
+++ b/src/comet/emulator/ers/ac3.py
@@ -31,6 +31,7 @@ class AC3Emulator(Emulator):
     @message(r"^ST([+-]\d{4})$")
     def set_target_temperature(self, value: str) -> str:
         self.target_temperature = float(value) / 10
+        self.temperature = self.target_temperature
         return "OK"
 
     @message(r"^RO$")

--- a/src/comet/emulator/ers/ac3.py
+++ b/src/comet/emulator/ers/ac3.py
@@ -74,4 +74,4 @@ class AC3Emulator(Emulator):
 
     @message(r"^RE$")
     def get_error(self) -> str:
-        return "E00"
+        return "E000"

--- a/src/comet/emulator/ers/ac3.py
+++ b/src/comet/emulator/ers/ac3.py
@@ -59,7 +59,7 @@ class AC3Emulator(Emulator):
     def get_hold_mode(self) -> str:
         return f"H{self.hold_mode:02d}"
 
-    @message(r"^SH([01][01])$")
+    @message(r"^SH([01])$")
     def set_hold_mode(self, value: str) -> str:
         val = int(value)
         if val == 0:

--- a/tests/test_driver_ers_ac3.py
+++ b/tests/test_driver_ers_ac3.py
@@ -150,20 +150,23 @@ def test_hold_mode_setter(resource):
     assert resource.buffer[0] == "SH0"
 
 
-def control_status(resource):
+def test_control_status(resource):
     device = AC3(resource)
     resource.buffer = ["I0"]
     assert device.control_status == device.STATUS_TEMPERATURE_REACHED
+    assert resource.buffer == ["RI"]
 
     resource.buffer = ["I1"]
     assert device.control_status == device.STATUS_HEATING
+    assert resource.buffer == ["RI"]
 
     resource.buffer = ["I2"]
     assert device.control_status == device.STATUS_COOLING
+    assert resource.buffer == ["RI"]
 
     resource.buffer = ["I8"]
     assert device.control_status == device.STATUS_ERROR
-    assert device.buffer == ["RI"]
+    assert resource.buffer == ["RI"]
 
 
 def test_next_error(resource):

--- a/tests/test_driver_ers_ac3.py
+++ b/tests/test_driver_ers_ac3.py
@@ -1,0 +1,158 @@
+import pytest
+from comet.driver.ers import AC3
+
+from .test_driver import resource
+
+def test_temperature_query(resource):
+    """Test temperature query."""
+    resource.buffer = ["C-600"]  # -60.0°C
+    device = AC3(resource)
+    assert device.temperature == -60.0
+    assert resource.buffer[0] == "RC"
+
+    resource.buffer = ["C+2450"]  # 245.0°C
+    assert device.temperature == 245.0
+    assert resource.buffer[0] == "RC"
+
+
+def test_target_temperature_setter(resource):
+    """Test target temperature setter."""
+    device = AC3(resource)
+    resource.buffer = ["OK"] 
+    device.target_temperature = 30.5
+    assert resource.buffer[0] == "ST+0305"
+
+    resource.buffer = ["OK"] 
+    device.target_temperature = -25.0
+    assert resource.buffer[0] == "ST-0250"
+
+    resource.buffer = ["OK"] 
+    device.target_temperature = 125.1
+    assert resource.buffer[0] == "ST+1251"
+
+    resource.buffer = ["OK"]
+    device.target_temperature = -70.0
+    assert resource.buffer[0] == "ST-0700"
+
+    resource.buffer = ["OK"]
+    device.target_temperature = 300.0
+    assert resource.buffer[0] == "ST+3000"
+
+    with pytest.raises(ValueError):
+        device.target_temperature = -70.1
+
+    resource.buffer = ["OK"]
+    with pytest.raises(ValueError):
+        device.target_temperature = 300.1
+
+
+def test_operating_mode_getter(resource):
+
+    device = AC3(resource)
+    resource.buffer = ["O1"]  # Mode 1
+    assert device.operating_mode == device.MODE_NORMAL
+
+    resource.buffer = ["O2"]  # Mode 2
+    assert device.operating_mode == device.MODE_STANDBY
+
+    resource.buffer = ["O3"]  # Mode 3
+    assert device.operating_mode == device.MODE_DEFROST
+
+    resource.buffer = ["O4"]  # Mode 4
+    assert device.operating_mode == device.MODE_PURGE
+
+def test_operating_mode_setter(resource):
+    device = AC3(resource)
+    resource.buffer = ["OK"]
+    device.operating_mode = device.MODE_NORMAL
+    assert resource.buffer[0] == "SO1"
+
+    resource.buffer = ["OK"]
+    device.operating_mode = device.MODE_STANDBY
+    assert resource.buffer[0] == "SO2"
+
+    resource.buffer = ["OK"]
+    device.operating_mode = device.MODE_DEFROST
+    assert resource.buffer[0] == "SO3"
+
+    resource.buffer = ["OK"]
+    device.operating_mode = device.MODE_PURGE
+    assert resource.buffer[0] == "SO4"
+
+    with pytest.raises(ValueError):
+        device.operating_mode = 5
+    
+    with pytest.raises(ValueError):
+        device.operating_mode = 0
+
+    with pytest.raises(ValueError):
+        device.operating_mode = -1
+
+def test_dewpoint_getter(resource):
+    device = AC3(resource)
+    resource.buffer = ["F-0585"] # -58.5°C
+    assert device.dewpoint == -58.5
+
+    resource.buffer = ["F+2450"] # 245.0°C
+    assert device.dewpoint == 245.0
+
+def test_dewpoint_control_getter(resource):
+    device = AC3(resource)
+    resource.buffer = ["D1"] # Dewpoint control on
+    assert device.dewpoint_control == True
+
+    resource.buffer = ["D0"] # Dewpoint control off
+    assert device.dewpoint_control == False
+
+def test_dewpoint_control_setter(resource):
+    device = AC3(resource)
+    resource.buffer = ["OK"]
+    device.dewpoint_control = True
+    assert resource.buffer[0] == "SD1"
+
+    resource.buffer = ["OK"]
+    device.dewpoint_control = False
+    assert resource.buffer[0] == "SD0"
+
+def test_hold_mode_getter(resource):
+    device = AC3(resource)
+    resource.buffer = ["H10"] # Hold mode on (but not yet reached)
+    assert device.hold_mode == True
+
+    resource.buffer = ["H11"] # Hold mode on (and reached)
+    assert device.hold_mode == True
+
+    resource.buffer = ["H00"] # Hold mode off
+    assert device.hold_mode == False
+
+def test_hold_mode_setter(resource):
+    device = AC3(resource)
+    resource.buffer = ["OK"]
+    device.hold_mode = True
+    assert resource.buffer[0] == "SH1"
+
+    resource.buffer = ["OK"]
+    device.hold_mode = False
+    assert resource.buffer[0] == "SH0"
+
+
+def get_control_status(resource):
+    device = AC3(resource)
+    resource.buffer = ["I0"]
+    assert device.get_control_status() == device.STATUS_TEMPERATURE_REACHED
+
+    resource.buffer = ["I1"]
+    assert device.get_control_status() == device.STATUS_HEATING
+
+    resource.buffer = ["I2"]
+    assert device.get_control_status() == device.STATUS_COOLING
+
+    resource.buffer = ["I8"]
+    assert device.get_control_status() == device.STATUS_ERROR
+
+
+def test_get_error(resource):
+    device = AC3(resource)
+    resource.buffer = ["E003"]
+    assert device.get_error_status() == 3
+    

--- a/tests/test_driver_ers_ac3.py
+++ b/tests/test_driver_ers_ac3.py
@@ -150,19 +150,19 @@ def test_hold_mode_setter(resource):
     assert resource.buffer[0] == "SH0"
 
 
-def get_control_status(resource):
+def control_status(resource):
     device = AC3(resource)
     resource.buffer = ["I0"]
-    assert device.get_control_status() == device.STATUS_TEMPERATURE_REACHED
+    assert device.control_status == device.STATUS_TEMPERATURE_REACHED
 
     resource.buffer = ["I1"]
-    assert device.get_control_status() == device.STATUS_HEATING
+    assert device.control_status == device.STATUS_HEATING
 
     resource.buffer = ["I2"]
-    assert device.get_control_status() == device.STATUS_COOLING
+    assert device.control_status == device.STATUS_COOLING
 
     resource.buffer = ["I8"]
-    assert device.get_control_status() == device.STATUS_ERROR
+    assert device.control_status == device.STATUS_ERROR
     assert device.buffer == ["RI"]
 
 

--- a/tests/test_emulator_ers_ac3.py
+++ b/tests/test_emulator_ers_ac3.py
@@ -8,6 +8,10 @@ def emulator():
     return AC3Emulator()
 
 
+def test_identify(emulator):
+    assert emulator("RI") == "I1"
+
+
 def test_get_temperature(emulator):
     assert emulator("RC") == "C+0250"
 
@@ -66,4 +70,4 @@ def test_get_control_status(emulator):
 
 
 def test_get_error_code(emulator):
-    assert emulator("RE") == "E00"
+    assert emulator("RE") == "E000"

--- a/tests/test_emulator_ers_ac3.py
+++ b/tests/test_emulator_ers_ac3.py
@@ -64,5 +64,6 @@ def test_set_hold_mode(emulator):
 def test_get_control_status(emulator):
     assert emulator("RI") == "I1"
 
+
 def test_get_error_code(emulator):
     assert emulator("RE") == "E00"

--- a/tests/test_emulator_ers_ac3.py
+++ b/tests/test_emulator_ers_ac3.py
@@ -58,10 +58,10 @@ def test_get_hold_mode(emulator):
 
 
 def test_set_hold_mode(emulator):
-    assert emulator("SH01") == "OK"
+    assert emulator("SH1") == "OK"
     assert emulator.hold_mode == 11
 
-    assert emulator("SH00") == "OK"
+    assert emulator("SH0") == "OK"
     assert emulator.hold_mode == 0
 
 

--- a/tests/test_emulator_ers_ac3.py
+++ b/tests/test_emulator_ers_ac3.py
@@ -1,0 +1,68 @@
+import pytest
+
+from comet.emulator.ers.ac3 import AC3Emulator
+
+
+@pytest.fixture
+def emulator():
+    return AC3Emulator()
+
+
+def test_get_temperature(emulator):
+    assert emulator("RC") == "C+0250"
+
+
+def test_get_target_temperature(emulator):
+    assert emulator("RT") == "T+0250"
+
+
+def test_set_target_temperature(emulator):
+    assert emulator("ST+0300") == "OK"
+    assert emulator.target_temperature == 30.0
+
+    assert emulator("ST-0300") == "OK"
+    assert emulator.target_temperature == -30.0
+
+
+def test_get_mode(emulator):
+    assert emulator("RO") == "O1"
+
+
+def test_set_mode(emulator):
+    assert emulator("SO2") == "OK"
+    assert emulator.mode == 2
+
+
+def test_get_dewpoint(emulator):
+    assert emulator("RF") == "F-0200"
+
+
+def test_get_dewpoint_control_status(emulator):
+    assert emulator("RD") == "D1"
+
+
+def test_set_dewpoint_control_status(emulator):
+    assert emulator("SD0") == "OK"
+    assert emulator.dewpoint_control_status == False
+
+    assert emulator("SD1") == "OK"
+    assert emulator.dewpoint_control_status == True
+
+
+def test_get_hold_mode(emulator):
+    assert emulator("RH") == "H11"
+
+
+def test_set_hold_mode(emulator):
+    assert emulator("SH01") == "OK"
+    assert emulator.hold_mode == 11
+
+    assert emulator("SH00") == "OK"
+    assert emulator.hold_mode == 0
+
+
+def test_get_control_status(emulator):
+    assert emulator("RI") == "I1"
+
+def test_get_error_code(emulator):
+    assert emulator("RE") == "E00"


### PR DESCRIPTION
The `identify` method is missing from the driver (and emulator) because there is no identify / software revision function provided by the thermal chuck controller